### PR TITLE
updated templates to remove static 'GB' suffix for quotas

### DIFF
--- a/ticket_utils/hpc_tickets.py
+++ b/ticket_utils/hpc_tickets.py
@@ -63,14 +63,14 @@ def hpc_added_to_group_ticket_text(project_path, user_path, group_name,
     return ticket_header + t
 
 
-def hpcvast_project_ticket_text(project_path: str, quota_gb: str, contact,
+def hpcvast_project_ticket_text(project_path: str, quota: str, contact,
                                 affected_client, assigned_to,
                                 watcher=None, parent_ticket_id=None):
     """
     Create ticket text for creating a new HPC Vast project.
 
     :param project_path: The path of the project.
-    :param quota_gb: The quota in GB for the project.
+    :param quota: The quota in GB for the project.
     :param contact: The UTLN of the contact person (requestor).
     :param affected_client: The UTLN of the affected client.
     :param assigned_to: The UTLN of the person to whom the ticket is assigned.
@@ -79,7 +79,7 @@ def hpcvast_project_ticket_text(project_path: str, quota_gb: str, contact,
     :return: A string containing the ticket text.
     """
     ticket_header = create_ticket_header(
-        short_description=f'Tier 1 HPC Storage: Creation | {quota_gb} GB | {project_path}',
+        short_description=f'Tier 1 HPC Storage: Creation | {quota} GB | {project_path}',
         close_notes='Project storage created!',
         affected_client=affected_client, contact=contact,
         assigned_to=assigned_to, watcher=watcher,
@@ -87,18 +87,18 @@ def hpcvast_project_ticket_text(project_path: str, quota_gb: str, contact,
     )
     footer = generate_text('footer')
     notifications = generate_text('notifications')
-    t = generate_text('hpc_storage', path=project_path, quota_gb=quota_gb,
+    t = generate_text('hpc_storage', path=project_path, quota=quota,
                       notifications=notifications, footer=footer)
     return ticket_header + t
 
 
-def hpcvast_increase_ticket_text(project_path, quota_gb,
+def hpcvast_increase_ticket_text(project_path, quota,
                                  contact, affected_client, assigned_to, 
                                  watcher=None, parent_ticket_id=None):
     """ Create ticket text for increasing the quota of an existing HPC Vast project.
 
     :param project_path: The path of the project.
-    :param quota_gb: The new quota in GB for the project.
+    :param quota: The new quota in GB for the project.
     :param contact: The UTLN of the contact person (requestor).
     :param affected_client: The UTLN of the affected client.
     :param assigned_to: The UTLN of the person to whom the ticket is assigned.
@@ -107,7 +107,7 @@ def hpcvast_increase_ticket_text(project_path, quota_gb,
     :return: A string containing the ticket text.
     """
     ticket_header = create_ticket_header(
-        short_description=f'Tier 1 HPC Storage: Increase | {quota_gb} GB | {project_path}',
+        short_description=f'Tier 1 HPC Storage: Increase | {quota} GB | {project_path}',
         close_notes='Quota increased!',
         affected_client=affected_client, contact=contact,
         assigned_to=assigned_to, watcher=watcher,
@@ -115,19 +115,19 @@ def hpcvast_increase_ticket_text(project_path, quota_gb,
     )
     footer = generate_text('footer')
     notifications = generate_text('notifications')
-    t = generate_text('hpc_storage_update', path=project_path, quota_gb=quota_gb,
+    t = generate_text('hpc_storage_update', path=project_path, quota=quota,
                       notifications=notifications, footer=footer)
     return ticket_header + t
 
 
-def rstore_share_ticket_text(share_name, quota_gb, group, approvers,
+def rstore_share_ticket_text(share_name, quota, group, approvers,
                              contact, affected_client, assigned_to, 
                              watcher=None, parent_ticket_id=None):
     """
     Create ticket text for creating a new RStore share.
 
     :param share_name: The name of the share.
-    :param quota_gb: The quota in GB for the share.
+    :param quota: The quota in GB for the share.
     :param group: The group to which the share belongs.
     :param approvers: List of approvers for the share.
     :param contact: The UTLN of the contact person (requestor).
@@ -138,7 +138,7 @@ def rstore_share_ticket_text(share_name, quota_gb, group, approvers,
     :return: A string containing the ticket text.
     """
     ticket_header = create_ticket_header(
-        short_description=f'Tier 1 RStore Storage: Creation | {quota_gb} GB | {share_name}',
+        short_description=f'Tier 1 RStore Storage: Creation | {quota} GB | {share_name}',
         close_notes='Share created!',
         affected_client=affected_client, contact=contact,
         assigned_to=assigned_to, watcher=watcher,
@@ -147,19 +147,19 @@ def rstore_share_ticket_text(share_name, quota_gb, group, approvers,
     footer = generate_text('footer')
     notifications = generate_text('notifications')
     instructions = generate_text('map_smb_drive', share_name=share_name)
-    t = generate_text('rstore_share', share_name=share_name, quota=quota_gb, owner=affected_client,
+    t = generate_text('rstore_share', share_name=share_name, quota=quota, owner=affected_client,
                       group=group, approvers=', '.join(approvers),
                       notifications=notifications, footer=footer, instructions=instructions)
     return ticket_header + t
 
 
-def rstore_increase_ticket_text(share_name, quota_gb,
+def rstore_increase_ticket_text(share_name, quota,
                                 contact, affected_client, assigned_to, 
                                 watcher=None, parent_ticket_id=None):
     """
     Create ticket text for increasing the quota of an existing RStore share.
     :param share_name: The name of the share.
-    :param quota_gb: The new quota in GB for the share.
+    :param quota: The new quota in GB for the share.
     :param contact: The UTLN of the contact person (requestor).
     :param affected_client: The UTLN of the affected client.
     :param assigned_to: The UTLN of the person to whom the ticket is assigned
@@ -168,7 +168,7 @@ def rstore_increase_ticket_text(share_name, quota_gb,
     :return: A string containing the ticket text.
     """
     ticket_header = create_ticket_header(
-        short_description=f'Tier 1 RStore Storage: Increase | {quota_gb} GB | {share_name}',
+        short_description=f'Tier 1 RStore Storage: Increase | {quota} GB | {share_name}',
         close_notes='Quota increased!',
         affected_client=affected_client, contact=contact,
         assigned_to=assigned_to, watcher=watcher,
@@ -176,19 +176,19 @@ def rstore_increase_ticket_text(share_name, quota_gb,
     )
     footer = generate_text('footer')
     notifications = generate_text('notifications')
-    t = generate_text('rstore_storage_update', path=share_name, quota=quota_gb,
+    t = generate_text('rstore_storage_update', path=share_name, quota=quota,
                       notifications=notifications, footer=footer)
     return ticket_header + t
 
 
-def course_directory_ticket_text(course_path: str, quota_gb: str, course_group: str,
+def course_directory_ticket_text(course_path: str, quota: str, course_group: str,
                                  admin_group: str, contact, affected_client, assigned_to, 
                                  watcher=None, parent_ticket_id=None):
     """
     Create ticket text for creating a new course directory.
 
     :param course_path: The path of the course.
-    :param quota_gb: The quota in GB for the course.
+    :param quota: The quota in GB for the course.
     :param course_group: The group name for the course.
     :param admin_group: The admin group name for the course.
     :param contact: The UTLN of the contact person (requestor).
@@ -199,14 +199,14 @@ def course_directory_ticket_text(course_path: str, quota_gb: str, course_group: 
     :return: A string containing the ticket text.
     """
     ticket_header = create_ticket_header(
-        short_description=f'HPC Class Storage: Creation | {quota_gb} GB | {course_path}',
+        short_description=f'HPC Class Storage: Creation | {quota} GB | {course_path}',
         close_notes='Course storage created!',
         affected_client=affected_client, contact=contact,
         assigned_to=assigned_to, watcher=watcher,
         parent_ticket_id=parent_ticket_id
     )
     footer = generate_text('footer')
-    t = generate_text('hpc_course_storage', course_dir=course_path, quota_gb=quota_gb,
+    t = generate_text('hpc_course_storage', course_dir=course_path, quota=quota,
                       course_group=course_group, admin_group=admin_group, footer=footer)
     return ticket_header + t
 

--- a/ticket_utils/templates/hpc_course_storage.j2
+++ b/ticket_utils/templates/hpc_course_storage.j2
@@ -5,7 +5,7 @@ The Tier 1 HPC storage creation for your class is completed. Below are the detai
 TIER 1 HPC CLASS STORAGE INFORMATION
 ==============================================
 Folder Path: {{ course_dir }} 
-Quota: {{ quota_gb }}GB         
+Quota: {{ quota }}         
 
 The permission setting for class folders is unique. There are two groups created for the class, admin group ({{ admin_group }}) which only consists instructors and TAs, and general class group ({{ course_group }}) which includes everyone in the class.
 

--- a/ticket_utils/templates/hpc_storage.j2
+++ b/ticket_utils/templates/hpc_storage.j2
@@ -5,7 +5,7 @@ Your new research storage has been created. Below are the details.
 Tier 1 HPC STORAGE INFORMATION
 =============================================
 Folder Path: {{ path }}
-Quota: {{ quota_gb }}GB
+Quota: {{ quota }}
 
 TIPS & RESOURCES
 

--- a/ticket_utils/templates/rstore_storage_update.j2
+++ b/ticket_utils/templates/rstore_storage_update.j2
@@ -1,6 +1,6 @@
 Hello,
 
-The requested quota increase from {{ old_quota }} to {{ new_quota }} has been applied to the Tier 1 RStore storage.
+The requested quota change from {{ old_quota }} to {{ new_quota }} has been applied to the Tier 1 RStore storage.
 {{ share_name }}
 
 {{ notifications }}


### PR DESCRIPTION
updated templates to remove static 'GB' suffix for quotas